### PR TITLE
Update invalid URL on API doc

### DIFF
--- a/downloading-data/using-the-api/getting-started.md
+++ b/downloading-data/using-the-api/getting-started.md
@@ -33,7 +33,7 @@ See the following sections for details on how to query different types of data.
 
 {% tabs %}
 {% tab title="Relevant Code Links" %}
-{% embed url="https://github.com/materialsproject/api/blob/main/mp_api/client/client.py#L41-L978" %}
+{% embed url="https://github.com/materialsproject/api/blob/main/mp_api/client/core/client.py#L41-L978" %}
 MPRester client code
 {% endembed %}
 {% endtab %}


### PR DESCRIPTION
The invalid URL was updated from

https://github.com/materialsproject/api/blob/main/mp_api/core/client/client.py#L41-L978

to

https://github.com/materialsproject/api/blob/main/mp_api/client/core/client.py#L41-L978