### PR TITLE
update docs for issue at mp-api #868

### DIFF
--- a/downloading-data/using-the-api/examples.md
+++ b/downloading-data/using-the-api/examples.md
@@ -37,7 +37,7 @@ with MPRester("your_api_key_here") as mpr:
 from mp_api.client import MPRester
 
 with MPRester("your_api_key_here") as mpr: 
-    docs = mpr.materials.search(material_ids=["mp-149"], fields=["calc_types"])
+    docs = mpr.materials.summary.search(material_ids=["mp-149"], fields=["calc_types"])
     task_ids = docs[0].calc_types.keys()
     task_types = docs[0].calc_types.values() 
     # -- Shortcut for a single Materials Project ID:

--- a/downloading-data/using-the-api/examples.md
+++ b/downloading-data/using-the-api/examples.md
@@ -37,7 +37,7 @@ with MPRester("your_api_key_here") as mpr:
 from mp_api.client import MPRester
 
 with MPRester("your_api_key_here") as mpr: 
-    docs = mpr.materials.materials.search(material_ids=["mp-149"], fields=["calc_types"])
+    docs = mpr.materials.search(material_ids=["mp-149"], fields=["calc_types"])
     task_ids = docs[0].calc_types.keys()
     task_types = docs[0].calc_types.values() 
     # -- Shortcut for a single Materials Project ID:


### PR DESCRIPTION
## Summary
This pull request addresses api [Issue #868](https://github.com/materialsproject/api/issues/868) by correcting API function calling.


Problem: in the example "Calculation (task) IDs and types for silicon (mp-149)"
Got 
```
AttributeError: 'MaterialsRester' object has no attribute 'materials'
```
when execute
```
docs = mpr.materials.materials.search(material_ids=["mp-149"], fields=["calc_types"])
```

Solution:
modify to 
```
docs = mpr.materials.search(material_ids=["mp-149"], fields=["calc_types"])
```
