### PR TITLE
Add documentation of environment variable `PMG_MAPI_KEY` to set API key for `MPRester`

### DIFF
--- a/downloading-data/using-the-api/getting-started.md
+++ b/downloading-data/using-the-api/getting-started.md
@@ -25,8 +25,13 @@ The **MPRester** client can then be imported and instantiated. It is preferred t
 ```python
 from mp_api.client import MPRester
 
+# Option One: Pass your API key directly as an argument.
 with MPRester("your_api_key_here") as mpr:
-    #do stuff with mpr...
+    # do stuff with mpr...
+
+# Option Two: Use the `PMG_MAPI_KEY` environment variable.
+# export PMG_MAPI_KEY="your_api_key_here"
+with MPRester() as mpr:
 ```
 
 See the following sections for details on how to query different types of data. Documentation for `MPRester`'s classes and methods can be found [here](https://materialsproject.github.io/api/).

--- a/downloading-data/using-the-api/getting-started.md
+++ b/downloading-data/using-the-api/getting-started.md
@@ -29,8 +29,8 @@ from mp_api.client import MPRester
 with MPRester("your_api_key_here") as mpr:
     # do stuff with mpr...
 
-# Option Two: Use the `PMG_MAPI_KEY` environment variable.
-# export PMG_MAPI_KEY="your_api_key_here"
+# Option Two: Use the `MP_API_KEY` environment variable:
+# export MP_API_KEY="your_api_key_here"
 with MPRester() as mpr:
 ```
 


### PR DESCRIPTION
- Add documentation of environment variable `PMG_MAPI_KEY` to set API key for `MPRester`, to close https://github.com/materialsproject/api/issues/949