### PR TITLE
fix r2scan pseudo potential document: Lu to Lu_3

### DIFF
--- a/methodology/materials-methodology/calculation-details/r2scan-calculations/pseudopotentials.md
+++ b/methodology/materials-methodology/calculation-details/r2scan-calculations/pseudopotentials.md
@@ -48,7 +48,7 @@ All calculations used pseudopotentials from the "PBE PAW datasets version 54" se
 | Kr      | Kr            |
 | La      | La            |
 | Li      | Li\_sv        |
-| Lu      | Lu            |
+| Lu      | Lu\_3         |
 | Mg      | Mg\_pv        |
 | Mn      | Mn\_pv        |
 | Mo      | Mo\_pv        |


### PR DESCRIPTION
## Summary
`Lu_3` was being used for r2SCAN calculations but was documented as `Lu`; this has been corrected.

## Todos
No

## Checklist


- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
